### PR TITLE
fixed date format bug

### DIFF
--- a/ui/src/common/DateInput/DateInput.js
+++ b/ui/src/common/DateInput/DateInput.js
@@ -156,6 +156,14 @@ export default function DateInput (props) {
 
     const fieldClassName = `${secondary ? 'secondary-field' : 'field'} ${active ? 'active' : ''} ${(locked && !active) ? 'locked' : ''}`;
 
+    function handleDateChange (date) {
+        if (date) {
+            onChange(date.toISOString().match(/^[0-9]{4}-[0-9]{2}-[0-9]{2}/g)[0]);
+        } else {
+            onChange('');
+        }
+    }
+
     return (
         <StyleContainer className="input-field">
             <div className={fieldClassName} style={{ height: `${height}` }}>
@@ -165,11 +173,11 @@ export default function DateInput (props) {
                 <DatePicker
                     placeholderText={placeholder}
                     selected={(value && value !== 'null') ? new Date(value) : ''}
-                    onChange={date => onChange(date ? date.toISOString() : date)}
+                    onChange={date => handleDateChange(date)}
                     onClickOutside={() => {}}
                     showYearDropdown={true}
                     showMonthDropdown={true}
-                    dateFormat='yyyy/MM/dd'
+                    dateFormat='yyyy-MM-dd'
                 />
             </div>
         </StyleContainer>

--- a/ui/src/components/EditContact/EditContact.js
+++ b/ui/src/components/EditContact/EditContact.js
@@ -231,8 +231,7 @@ export default function EditContact (props) {
     }
 
     function handleSaveContact () {
-        console.log('attempted save');
-        // validate inputs, error messages if needed TODO
+        // validate inputs, prompt user with actionable errors
         let valid = true;
         if (!pendingChanges.firstName) {
             valid = false;
@@ -249,11 +248,11 @@ export default function EditContact (props) {
         if (!entityIsOrganization &&
                 pendingChanges.dateOfBirth &&
                 (pendingChanges.dateOfBirth &&
-                    !pendingChanges.dateOfBirth.match(/^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}\.[0-9]{3}Z$/g)
+                    !pendingChanges.dateOfBirth.match(/^[0-9]{4}-[0-9]{2}-[0-9]{2}$/g)
                 )
         ) {
             valid = false;
-            setError({ ...error, ...{ dateOfBirth: 'Expect format: YYYY-MM-DD' } });
+            setError({ ...error, ...{ dateOfBirth: 'Expected format: YYYY-MM-DD' } });
         }
 
         if (valid) {


### PR DESCRIPTION
## WHAT
Bug was preventing saving manually entered dates

## WHY
The regex was not setup properly to handle both ISO formatting from the plugin and plaintext user input

## TEST
Run eslint and unit tests
Test saving:
- a blank date
- a date with a value
- the same value
- a changed value
- no date when there was a value