### PR TITLE
Feature/fetch event note by relation

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -186,25 +186,18 @@ app.get('/api/notes/all', (req, res) => {
 
 //accepts requests of the form: /api/notes?order=id?results=3&page=1?direction=[ASC|DESC]?search=string
 app.get("/api/notes", (req, res) => {
-    const { results, page, order, direction, searchTerm, filters } = req.query;
-    let sql = `SELECT * FROM notes`;
-
-    //apply search
-    if(searchTerm && filters) {
-        const searchFilters = filters.split(',');
-        sql = sql + ` WHERE ${searchFilters[0]} LIKE '%${searchTerm}%'`;
-        searchFilters.forEach((filter, index) => {
-            if(index) {
-                sql = sql + ` OR ${filter} LIKE '%${searchTerm}%'`
-            }
-        });
+    const { results, page, order, direction, searchTerm, filters, relatedContacts, relatedEvents } = req.query;
+    const relationships = {};
+    if (relatedContacts) {
+        relationships.contacts = relatedContacts.split(',');
+    }
+    if (relatedEvents) {
+        relationships.events = relatedEvents.split(',');
     }
 
-    const sql_metadata = sql;
-    //apply sort order and pagination
-    sql = sql+` ORDER BY ${order} ${direction} LIMIT ${results} OFFSET ((${page - 1})* ${results})`;
+    let sqlPre = `SELECT * FROM relations LEFT JOIN notes ON relations.noteId = notes.id`;
 
-    db.all(sql, (err, rows) => {
+    db.all(sqlPre, (err, rows) => {
         if (err) {
             console.log(err);
             res.status = ERROR_CODE;
@@ -213,22 +206,108 @@ app.get("/api/notes", (req, res) => {
             res.status = NOT_FOUND_CODE;
             res.json({message: 'NOT FOUND'});
         } else {
-            db.all(sql_metadata, (err, result) => {
+            const relatedRecordMap = new Map();
+
+            // create map where each record id has an object of their existing relationships
+            rows.forEach((row) => {
+                if (row.id) {
+                    if (!relatedRecordMap.get(row.id)) {
+                        relatedRecordMap.set(row.id, {
+                            contacts: [],
+                            events: [],
+                            notes: []
+                        });
+                    }
+                    const thisRecordEntry = relatedRecordMap.get(row.id);
+                    if (row.contactId && !thisRecordEntry.contacts.includes(row.contactId)) {
+                        relatedRecordMap.set(row.id, {
+                            ...thisRecordEntry,
+                            contacts: [...thisRecordEntry.contacts, row.contactId]
+                        });
+                    }
+                    if (row.eventId && !thisRecordEntry.events.includes(row.eventId)) {
+                        const possiblyUpdatedRecord = relatedRecordMap.get(row.id);
+                        relatedRecordMap.set(row.id, {
+                            ...possiblyUpdatedRecord,
+                            events: [...possiblyUpdatedRecord.events, row.eventId]
+                        });
+                    }
+                    if (row.noteId && !thisRecordEntry.notes.includes(row.noteId)) {
+                        const possiblyUpdatedRecord = relatedRecordMap.get(row.id);
+                        relatedRecordMap.set(row.id, {
+                            ...possiblyUpdatedRecord,
+                            notes: [...possiblyUpdatedRecord.notes, row.noteId]
+                        });
+                    }
+                }
+            });
+
+            // filter for just the record ids with the expected relations
+            const filteredIds = [];
+            const mapKeys = relatedRecordMap.keys();
+            let nextMapKey = mapKeys.next();
+            while (nextMapKey.done === false) {
+                const key = nextMapKey.value;
+                const recordRelations = relatedRecordMap.get(key);
+                const hasAllExpectedRelations = Object.keys(relationships).every((recordIdType) => {
+                    return relationships[recordIdType].every((id) => {
+                        return recordRelations[recordIdType].find(i => i === parseInt(id));
+                    });
+                });
+                if (hasAllExpectedRelations) {
+                    filteredIds.push(key);
+                }
+
+                nextMapKey = mapKeys.next();
+            }
+
+            let sql = `SELECT * FROM notes`;
+
+            //apply search
+            if(searchTerm && filters) {
+                const searchFilters = filters.split(',');
+                sql = sql + ` WHERE ${searchFilters[0]} LIKE '%${searchTerm}%'`;
+                searchFilters.forEach((filter, index) => {
+                    if(index) {
+                        sql = sql + ` OR ${filter} LIKE '%${searchTerm}%'`;
+                    }
+                });
+                sql = sql+` AND id IN (${filteredIds})`;
+            } else {
+                sql = sql+` WHERE id IN (${filteredIds})`;
+            }
+
+            const sql_metadata = sql;
+            //apply sort order and pagination
+            sql = sql+` ORDER BY ${order} ${direction} LIMIT ${results} OFFSET ((${page - 1})* ${results})`;
+
+            db.all(sql, (err, rows) => {
                 if (err) {
+                    console.log(err);
                     res.status = ERROR_CODE;
-                    return console.error(err.message);
-                } else if (!result) {
+                    res.json(err);
+                } else if (!rows) {
                     res.status = NOT_FOUND_CODE;
-                    return;
+                    res.json({message: 'NOT FOUND'});
                 } else {
-                    totalResults = result.length;
-                    res.json({
-                        results: rows,
-                        resultCount: rows.length,
-                        pageSize: parseInt(results),
-                        totalCount: totalResults,
-                        pageCount: Math.ceil(totalResults / parseInt(results)),
-                        currentPage: parseInt(page)
+                    db.all(sql_metadata, (err, result) => {
+                        if (err) {
+                            res.status = ERROR_CODE;
+                            return console.error(err.message);
+                        } else if (!result) {
+                            res.status = NOT_FOUND_CODE;
+                            return;
+                        } else {
+                            totalResults = result.length;
+                            res.json({
+                                results: rows,
+                                resultCount: rows.length,
+                                pageSize: parseInt(results),
+                                totalCount: totalResults,
+                                pageCount: Math.ceil(totalResults / parseInt(results)),
+                                currentPage: parseInt(page)
+                            });
+                        }
                     });
                 }
             });
@@ -427,15 +506,17 @@ app.get("/api/contacts", (req, res) => {
                         });
                     }
                     if (row.eventId && !thisRecordEntry.events.includes(row.eventId)) {
+                        const possiblyUpdatedRecord = relatedRecordMap.get(row.id);
                         relatedRecordMap.set(row.id, {
-                            ...thisRecordEntry,
-                            events: [...thisRecordEntry.events, row.eventId]
+                            ...possiblyUpdatedRecord,
+                            events: [...possiblyUpdatedRecord.events, row.eventId]
                         });
                     }
                     if (row.noteId && !thisRecordEntry.notes.includes(row.noteId)) {
+                        const possiblyUpdatedRecord = relatedRecordMap.get(row.id);
                         relatedRecordMap.set(row.id, {
-                            ...thisRecordEntry,
-                            notes: [...thisRecordEntry.notes, row.noteId]
+                            ...possiblyUpdatedRecord,
+                            notes: [...possiblyUpdatedRecord.notes, row.noteId]
                         });
                     }
                 }
@@ -667,15 +748,17 @@ app.get("/api/events", (req, res) => {
                         });
                     }
                     if (row.eventId && !thisRecordEntry.events.includes(row.eventId)) {
+                        const possiblyUpdatedRecord = relatedRecordMap.get(row.id);
                         relatedRecordMap.set(row.id, {
-                            ...thisRecordEntry,
-                            events: [...thisRecordEntry.events, row.eventId]
+                            ...possiblyUpdatedRecord,
+                            events: [...possiblyUpdatedRecord.events, row.eventId]
                         });
                     }
                     if (row.noteId && !thisRecordEntry.notes.includes(row.noteId)) {
+                        const possiblyUpdatedRecord = relatedRecordMap.get(row.id);
                         relatedRecordMap.set(row.id, {
-                            ...thisRecordEntry,
-                            notes: [...thisRecordEntry.notes, row.noteId]
+                            ...possiblyUpdatedRecord,
+                            notes: [...possiblyUpdatedRecord.notes, row.noteId]
                         });
                     }
                 }
@@ -988,15 +1071,17 @@ app.get("/api/records-by-relation/recordType/:recordType", async (req, res) => {
                         });
                     }
                     if (row.eventId && !thisRecordEntry.events.includes(row.eventId)) {
+                        const possiblyUpdatedRecord = relatedRecordMap.get(row.id);
                         relatedRecordMap.set(row.id, {
-                            ...thisRecordEntry,
-                            events: [...thisRecordEntry.events, row.eventId]
+                            ...possiblyUpdatedRecord,
+                            events: [...possiblyUpdatedRecord.events, row.eventId]
                         });
                     }
                     if (row.noteId && !thisRecordEntry.notes.includes(row.noteId)) {
+                        const possiblyUpdatedRecord = relatedRecordMap.get(row.id);
                         relatedRecordMap.set(row.id, {
-                            ...thisRecordEntry,
-                            notes: [...thisRecordEntry.notes, row.noteId]
+                            ...possiblyUpdatedRecord,
+                            notes: [...possiblyUpdatedRecord.notes, row.noteId]
                         });
                     }
                 }

--- a/ui/src/components/ContactsBrowse/ContactsBrowse.js
+++ b/ui/src/components/ContactsBrowse/ContactsBrowse.js
@@ -48,11 +48,11 @@ export default function ContactsBrowse (props) {
         isContactListPending,
         getContactList,
         events,
-        isEventListPending,
-        getEventList,
+        isAllEventsPending,
+        getAllEvents,
         notes,
-        isNoteListPending,
-        getNoteList
+        isAllNotesPending,
+        getAllNotes
     } = props;
     const [activeFilters, setActiveFilters] = useState([]);
     const [page, setPage] = useState(1);
@@ -128,8 +128,8 @@ export default function ContactsBrowse (props) {
 
     useEffect(() => {
         initiateSearch();
-        getEventList();
-        getNoteList();
+        getAllEvents();
+        getAllNotes();
     }, []);
 
     useEffect(() => {
@@ -184,7 +184,7 @@ export default function ContactsBrowse (props) {
                     currentDirection={direction}
                     handleDirectionUpdate={setDirection}
                 />
-                {isEventListPending || isNoteListPending
+                {isAllEventsPending || isAllNotesPending
                     ? <></>
                     : (
                         <RelationMatchContainer>
@@ -243,11 +243,11 @@ ContactsBrowse.propTypes = {
     contactListError: PropTypes.string.isRequired,
     getContactList: PropTypes.func.isRequired,
     events: PropTypes.object.isRequired,
-    isEventListPending: PropTypes.bool.isRequired,
-    eventListError: PropTypes.string.isRequired,
-    getEventList: PropTypes.func.isRequired,
+    isAllEventsPending: PropTypes.bool.isRequired,
+    allEventsError: PropTypes.string.isRequired,
+    getAllEvents: PropTypes.func.isRequired,
     notes: PropTypes.object.isRequired,
-    isNoteListPending: PropTypes.bool.isRequired,
-    noteListError: PropTypes.string.isRequired,
-    getNoteList: PropTypes.func.isRequired
+    isAllNotesPending: PropTypes.bool.isRequired,
+    allNotesError: PropTypes.string.isRequired,
+    getAllNotes: PropTypes.func.isRequired
 };

--- a/ui/src/components/ContactsBrowse/index.js
+++ b/ui/src/components/ContactsBrowse/index.js
@@ -2,8 +2,8 @@ import ContactsBrowse from './ContactsBrowse';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import { getContactList } from '../../store/ContactList/actions';
-import { getEventList } from '../../store/EventList/actions';
-import { getNoteList } from '../../store/NoteList/actions';
+import { getAllEvents } from '../../store/EventList/actions';
+import { getAllNotes } from '../../store/NoteList/actions';
 
 function mapStateToProps (state) {
     return {
@@ -11,11 +11,11 @@ function mapStateToProps (state) {
         isContactListPending: state.contactList.isContactListPending,
         contactListError: state.contactList.contactListError,
         events: state.eventList.events,
-        isEventListPending: state.eventList.isEventListPending,
-        eventListError: state.eventList.eventListError,
+        isAllEventsPending: state.eventList.isAllEventsPending,
+        allEventsError: state.eventList.allEventsError,
         notes: state.noteList.notes,
-        isNoteListPending: state.noteList.isNoteListPending,
-        noteListError: state.noteList.noteListError
+        isAllNotesPending: state.noteList.isAllNotesPending,
+        allNotesError: state.noteList.allNotesError
     };
 }
 
@@ -23,8 +23,8 @@ const mapDispatchToProps = dispatch =>
     bindActionCreators(
         {
             getContactList,
-            getEventList,
-            getNoteList
+            getAllEvents,
+            getAllNotes
         },
         dispatch
     );

--- a/ui/src/components/EventsBrowse/EventsBrowse.js
+++ b/ui/src/components/EventsBrowse/EventsBrowse.js
@@ -8,6 +8,7 @@ import { RESULTS_PER_PAGE } from '../../common/constants/constants';
 import PropTypes from 'prop-types';
 import LoadingSpinner from '../../common/LoadingSpinner/LoadingSpinner';
 import ScrollContainer from '../../common/ScrollContainer';
+import MultiSelect from '../../common/MultiSelect';
 
 const ContentWrapper = styled.div`
     padding: 0 1em;
@@ -35,17 +36,31 @@ const NoResultsMessage = styled.div`
     padding-left: 6em;
 `;
 
+const RelationMatchContainer = styled.div`
+    display: flex;
+    justify-content: space-between;
+    margin: 0 2.5em;
+`;
+
 export default function EventsBrowse (props) {
     const {
         events,
         isEventListPending,
-        getEventList
+        getEventList,
+        isAllContactsPending,
+        getAllContacts,
+        contacts,
+        isAllNotesPending,
+        getAllNotes,
+        notes
     } = props;
     const [activeFilters, setActiveFilters] = useState([]);
     const [page, setPage] = useState(1);
     const [searchTerm, setSearchTerm] = useState('');
     const [searchOrderBy, setSearchOrderBy] = useState('title');
     const [direction, setDirection] = useState('ASC'); // ASC if ascending, DESC if descending
+    const [appliedContacts, setAppliedContacts] = useState('');
+    const [appliedNotes, setAppliedNotes] = useState('');
 
     const searchFields = [
         {
@@ -90,11 +105,13 @@ export default function EventsBrowse (props) {
 
     useEffect(() => {
         initiateSearch();
+        getAllContacts();
+        getAllNotes();
     }, []);
 
     useEffect(() => {
         initiateSearch();
-    }, [page, searchOrderBy, direction]);
+    }, [page, searchOrderBy, direction, appliedContacts, appliedNotes]);
 
     useEffect(() => {
         if (searchTerm !== '') {
@@ -124,7 +141,7 @@ export default function EventsBrowse (props) {
     }
 
     function initiateSearch () {
-        getEventList(RESULTS_PER_PAGE, page, searchTerm, searchOrderBy, direction, activeFilters);
+        getEventList(RESULTS_PER_PAGE, page, searchTerm, searchOrderBy, direction, activeFilters, appliedContacts, appliedNotes);
     }
 
     return (
@@ -145,6 +162,22 @@ export default function EventsBrowse (props) {
                     currentDirection={direction}
                     handleDirectionUpdate={setDirection}
                 />
+                {isAllContactsPending || isAllNotesPending
+                    ? <></>
+                    : (
+                        <RelationMatchContainer>
+                            <MultiSelect
+                                title={'CONTACT RELATIONS'}
+                                options={contacts.results.map(contact => { return { ...contact, title: `${contact.firstName} ${contact.lastName}` }; })}
+                                onChange={(val) => { setAppliedContacts(val.map(v => v.id)); }}
+                            />
+                            <MultiSelect
+                                title={'NOTE RELATIONS'}
+                                options={notes.results}
+                                onChange={(val) => setAppliedNotes(val.map(v => v.id))}
+                            />
+                        </RelationMatchContainer>
+                    )}
                 <ScrollContainer
                     className="scroll-container"
                     style={ { margin: '2em 2em 0 2em' } }
@@ -188,5 +221,13 @@ EventsBrowse.propTypes = {
     events: PropTypes.object.isRequired,
     isEventListPending: PropTypes.bool.isRequired,
     eventListError: PropTypes.string.isRequired,
-    getEventList: PropTypes.func.isRequired
+    getEventList: PropTypes.func.isRequired,
+    contacts: PropTypes.object.isRequired,
+    isAllContactsPending: PropTypes.bool.isRequired,
+    allContactsError: PropTypes.string.isRequired,
+    getAllContacts: PropTypes.func.isRequired,
+    notes: PropTypes.object.isRequired,
+    isAllNotesPending: PropTypes.bool.isRequired,
+    allNotesError: PropTypes.string.isRequired,
+    getAllNotes: PropTypes.func.isRequired
 };

--- a/ui/src/components/EventsBrowse/index.js
+++ b/ui/src/components/EventsBrowse/index.js
@@ -2,19 +2,29 @@ import EventsBrowse from './EventsBrowse';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import { getEventList } from '../../store/EventList/actions';
+import { getAllContacts } from '../../store/ContactList/actions';
+import { getAllNotes } from '../../store/NoteList/actions';
 
 function mapStateToProps (state) {
     return {
         events: state.eventList.events,
         isEventListPending: state.eventList.isEventListPending,
-        eventListError: state.eventList.eventListError
+        eventListError: state.eventList.eventListError,
+        isAllContactsPending: state.contactList.isAllContactsPending,
+        allContactsError: state.contactList.allContactsError,
+        contacts: state.contactList.contacts,
+        isAllNotesPending: state.noteList.isAllNotesPending,
+        allNotesError: state.noteList.allNotesError,
+        notes: state.noteList.notes
     };
 }
 
 const mapDispatchToProps = dispatch =>
     bindActionCreators(
         {
-            getEventList
+            getEventList,
+            getAllContacts,
+            getAllNotes
         },
         dispatch
     );

--- a/ui/src/components/NotesBrowse/NotesBrowse.js
+++ b/ui/src/components/NotesBrowse/NotesBrowse.js
@@ -8,6 +8,7 @@ import { RESULTS_PER_PAGE } from '../../common/constants/constants';
 import PropTypes from 'prop-types';
 import LoadingSpinner from '../../common/LoadingSpinner/LoadingSpinner';
 import ScrollContainer from '../../common/ScrollContainer';
+import MultiSelect from '../../common/MultiSelect';
 
 const ContentWrapper = styled.div`
     padding: 0 1em;
@@ -35,17 +36,31 @@ const NoResultsMessage = styled.div`
     padding-left: 6em;
 `;
 
+const RelationMatchContainer = styled.div`
+    display: flex;
+    justify-content: space-between;
+    margin: 0 2.5em;
+`;
+
 export default function NotesBrowse (props) {
     const {
         notes,
         isNoteListPending,
-        getNoteList
+        getNoteList,
+        contacts,
+        isAllContactsPending,
+        getAllContacts,
+        events,
+        isAllEventsPending,
+        getAllEvents
     } = props;
     const [activeFilters, setActiveFilters] = useState([]);
     const [page, setPage] = useState(1);
     const [searchTerm, setSearchTerm] = useState('');
     const [searchOrderBy, setSearchOrderBy] = useState('title');
     const [direction, setDirection] = useState('ASC'); // ASC if ascending, DESC if descending
+    const [appliedContacts, setAppliedContacts] = useState('');
+    const [appliedEvents, setAppliedEvents] = useState('');
 
     const searchFields = [
         {
@@ -100,11 +115,13 @@ export default function NotesBrowse (props) {
 
     useEffect(() => {
         initiateSearch();
+        getAllContacts();
+        getAllEvents();
     }, []);
 
     useEffect(() => {
         initiateSearch();
-    }, [page, searchOrderBy, direction]);
+    }, [page, searchOrderBy, direction, appliedContacts, appliedEvents]);
 
     useEffect(() => {
         if (searchTerm !== '') {
@@ -134,7 +151,7 @@ export default function NotesBrowse (props) {
     }
 
     function initiateSearch () {
-        getNoteList(RESULTS_PER_PAGE, page, searchTerm, searchOrderBy, direction, activeFilters);
+        getNoteList(RESULTS_PER_PAGE, page, searchTerm, searchOrderBy, direction, activeFilters, appliedContacts, appliedEvents);
     }
 
     return (
@@ -155,6 +172,22 @@ export default function NotesBrowse (props) {
                     currentDirection={direction}
                     handleDirectionUpdate={setDirection}
                 />
+                {isAllContactsPending || isAllEventsPending
+                    ? <></>
+                    : (
+                        <RelationMatchContainer>
+                            <MultiSelect
+                                title={'CONTACT RELATIONS'}
+                                options={contacts.results.map(contact => { return { ...contact, title: `${contact.firstName} ${contact.lastName}` }; })}
+                                onChange={(val) => { setAppliedContacts(val.map(v => v.id)); }}
+                            />
+                            <MultiSelect
+                                title={'EVENT RELATIONS'}
+                                options={events.results}
+                                onChange={(val) => setAppliedEvents(val.map(v => v.id))}
+                            />
+                        </RelationMatchContainer>
+                    )}
                 <ScrollContainer
                     className="scroll-container"
                     style={ { margin: '2em 2em 0 2em' } }
@@ -198,5 +231,13 @@ NotesBrowse.propTypes = {
     notes: PropTypes.object.isRequired,
     isNoteListPending: PropTypes.bool.isRequired,
     noteListError: PropTypes.string.isRequired,
-    getNoteList: PropTypes.func.isRequired
+    getNoteList: PropTypes.func.isRequired,
+    contacts: PropTypes.object.isRequired,
+    isAllContactsPending: PropTypes.bool.isRequired,
+    allContactsError: PropTypes.string.isRequired,
+    getAllContacts: PropTypes.func.isRequired,
+    events: PropTypes.object.isRequired,
+    isAllEventsPending: PropTypes.bool.isRequired,
+    allEventsError: PropTypes.string.isRequired,
+    getAllEvents: PropTypes.func.isRequired
 };

--- a/ui/src/components/NotesBrowse/index.js
+++ b/ui/src/components/NotesBrowse/index.js
@@ -2,19 +2,29 @@ import NotesBrowse from './NotesBrowse';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import { getNoteList } from '../../store/NoteList/actions';
+import { getAllContacts } from '../../store/ContactList/actions';
+import { getAllEvents } from '../../store/EventList/actions';
 
 function mapStateToProps (state) {
     return {
         notes: state.noteList.notes,
         isNoteListPending: state.noteList.isNoteListPending,
-        noteListError: state.noteList.noteListError
+        noteListError: state.noteList.noteListError,
+        contacts: state.contactList.contacts,
+        isAllContactsPending: state.contactList.isAllContactsPending,
+        allContactsError: state.contactList.allContactsError,
+        events: state.eventList.events,
+        isAllEventsPending: state.eventList.isAllEventsPending,
+        allEventsError: state.eventList.allEventsError
     };
 }
 
 const mapDispatchToProps = dispatch =>
     bindActionCreators(
         {
-            getNoteList
+            getNoteList,
+            getAllContacts,
+            getAllEvents
         },
         dispatch
     );

--- a/ui/src/services/EventListService.js
+++ b/ui/src/services/EventListService.js
@@ -1,14 +1,14 @@
 import axios from '../configs/axiosBasic';
 
 export default class EventListService {
-    static getEventList (results, page, searchTerm, order, direction, filters) {
+    static getEventList (results, page, searchTerm, order, direction, filters, appliedContacts, appliedNotes) {
         // to GET all events, pass results = number of total events, and page = 1
         results = results || 5;
         page = page || 1;
         order = order || 'title';
         direction = direction || 'ASC';
         searchTerm = searchTerm || '';
-        return axios.get(`/events?results=${results}&page=${page}&order=${order}&direction=${direction}&searchTerm=${searchTerm}&filters=${filters}`);
+        return axios.get(`/events?results=${results}&page=${page}&order=${order}&direction=${direction}&searchTerm=${searchTerm}&filters=${filters}&relatedContacts=${appliedContacts}&relatedNotes=${appliedNotes}`);
     }
 
     static getAllEvents () {

--- a/ui/src/services/NoteListService.js
+++ b/ui/src/services/NoteListService.js
@@ -1,14 +1,14 @@
 import axios from '../configs/axiosBasic';
 
 export default class NoteListService {
-    static getNoteList (results, page, searchTerm, order, direction, filters) {
+    static getNoteList (results, page, searchTerm, order, direction, filters, appliedContacts, appliedEvents) {
         // to GET all notes, pass results = number of total notes, and page = 1
         results = results || 5;
         page = page || 1;
         order = order || 'title';
         direction = direction || 'ASC';
         searchTerm = searchTerm || '';
-        return axios.get(`/notes?results=${results}&page=${page}&order=${order}&direction=${direction}&searchTerm=${searchTerm}&filters=${filters}`);
+        return axios.get(`/notes?results=${results}&page=${page}&order=${order}&direction=${direction}&searchTerm=${searchTerm}&filters=${filters}&relatedContacts=${appliedContacts}&relatedEvents=${appliedEvents}`);
     }
 
     static getAllNotes () {

--- a/ui/src/store/EventList/actions.js
+++ b/ui/src/store/EventList/actions.js
@@ -23,11 +23,11 @@ function getEventListError (error) {
     };
 }
 
-export function getEventList (results, page, searchTerm, order, direction, filters) {
+export function getEventList (results, page, searchTerm, order, direction, filters, appliedContacts, appliedNotes) {
     return async dispatch => {
         dispatch(getEventListLoading());
         try {
-            const response = await EventListService.getEventList(results, page, searchTerm, order, direction, filters);
+            const response = await EventListService.getEventList(results, page, searchTerm, order, direction, filters, appliedContacts, appliedNotes);
             dispatch(getEventListSuccess(response));
         } catch (e) {
             dispatch(getEventListError(e));

--- a/ui/src/store/NoteList/actions.js
+++ b/ui/src/store/NoteList/actions.js
@@ -23,11 +23,11 @@ function getNoteListError (error) {
     };
 }
 
-export function getNoteList (results, page, searchTerm, order, direction, filters) {
+export function getNoteList (results, page, searchTerm, order, direction, filters, appliedContacts, appliedEvents) {
     return async dispatch => {
         dispatch(getNoteListLoading());
         try {
-            const response = await NoteListService.getNoteList(results, page, searchTerm, order, direction, filters);
+            const response = await NoteListService.getNoteList(results, page, searchTerm, order, direction, filters, appliedContacts, appliedEvents);
             dispatch(getNoteListSuccess(response));
         } catch (e) {
             dispatch(getNoteListError(e));


### PR DESCRIPTION
As with contacts, both events and notes should be able to fetch their records having been filtered by their relations to other types of records.

This branch introduces the logic found in the contacts api and BrowseContacts components into the corresponding events and notes, so that users can select specific relations to filter by.